### PR TITLE
Add optional serde feature, update rust edition and rand version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scalable_cuckoo_filter"
 edition = "2018"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Takeru Ohta <phjgt308@gmail.com>"]
 description = "A variant of Cuckoo Filter whose size automatically scales as necessary"
 homepage = "https://github.com/sile/scalable_cuckoo_filter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "scalable_cuckoo_filter"
+edition = "2018"
 version = "0.1.2"
 authors = ["Takeru Ohta <phjgt308@gmail.com>"]
 description = "A variant of Cuckoo Filter whose size automatically scales as necessary"
@@ -15,5 +16,5 @@ travis-ci = {repository = "sile/scalable_cuckoo_filter"}
 codecov = {repository = "sile/scalable_cuckoo_filter"}
 
 [dependencies]
-rand = "0.5"
-siphasher = "0.2"
+rand = "0.7"
+siphasher = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "scalable_cuckoo_filter"
 edition = "2018"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Takeru Ohta <phjgt308@gmail.com>"]
 description = "A variant of Cuckoo Filter whose size automatically scales as necessary"
 homepage = "https://github.com/sile/scalable_cuckoo_filter"
@@ -19,7 +19,7 @@ travis-ci = {repository = "sile/scalable_cuckoo_filter"}
 codecov = {repository = "sile/scalable_cuckoo_filter"}
 
 [dependencies]
-rand = "0.7"
+rand = "0.8"
 siphasher = "0.3"
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 serde_bytes = { version = "0.11", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ keywords = ["cuckoo-filter", "bloom-filter"]
 categories = ["data-structures"]
 license = "MIT"
 
+[features]
+serde_support = ["serde","serde_bytes"]
+
 [badges]
 travis-ci = {repository = "sile/scalable_cuckoo_filter"}
 codecov = {repository = "sile/scalable_cuckoo_filter"}
@@ -18,3 +21,8 @@ codecov = {repository = "sile/scalable_cuckoo_filter"}
 [dependencies]
 rand = "0.7"
 siphasher = "0.3"
+serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
+serde_bytes = { version = "0.11", optional = true }
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -1,5 +1,9 @@
+#[cfg(feature = "serde_support")]
+use serde::{Deserialize, Serialize};
+
 #[derive(Debug)]
-pub struct Bits(Vec<u8>);
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
+pub struct Bits(#[cfg_attr(feature = "serde_support", serde(with = "serde_bytes"))] Vec<u8>);
 impl Bits {
     pub fn new(size_hint: usize) -> Self {
         Bits(vec![0; (size_hint + 7) / 8])

--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -1,6 +1,6 @@
 use rand::Rng;
 
-use bits::Bits;
+use crate::bits::Bits;
 
 #[derive(Debug)]
 pub struct Buckets {

--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -2,7 +2,11 @@ use rand::Rng;
 
 use crate::bits::Bits;
 
+#[cfg(feature = "serde_support")]
+use serde::{Deserialize, Serialize};
+
 #[derive(Debug)]
+#[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct Buckets {
     fingerprint_bitwidth: usize, // fingerprint length in bits
     entries_per_bucket: usize,   // number of entries per bucket

--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -113,7 +113,7 @@ impl Buckets {
         bucket_index: usize,
         fingerprint: u64,
     ) -> u64 {
-        let i = rng.gen_range(0, self.entries_per_bucket);
+        let i = rng.gen_range(0..self.entries_per_bucket);
         let f = self.get_fingerprint(bucket_index, i);
         self.set_fingerprint(bucket_index, i, fingerprint);
 

--- a/src/cuckoo_filter.rs
+++ b/src/cuckoo_filter.rs
@@ -5,7 +5,11 @@ use std::mem;
 
 use crate::buckets::Buckets;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CuckooFilter {
     buckets: Buckets,
     max_kicks: usize,
@@ -146,6 +150,7 @@ impl CuckooFilter {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 struct ExceptionalItems(Vec<(u64, usize)>);
 impl ExceptionalItems {
     fn new() -> Self {

--- a/src/cuckoo_filter.rs
+++ b/src/cuckoo_filter.rs
@@ -3,8 +3,7 @@ use std::cmp;
 use std::hash::Hasher;
 use std::mem;
 
-use buckets::Buckets;
-use hash;
+use crate::buckets::Buckets;
 
 #[derive(Debug)]
 pub struct CuckooFilter {
@@ -59,7 +58,9 @@ impl CuckooFilter {
     pub fn contains<H: Hasher + Clone>(&self, hasher: &H, item_hash: u64) -> bool {
         let fingerprint = self.buckets.fingerprint(item_hash);
         let i0 = self.buckets.index(item_hash);
-        let i1 = self.buckets.index(i0 as u64 ^ hash(hasher, &fingerprint));
+        let i1 = self
+            .buckets
+            .index(i0 as u64 ^ crate::hash(hasher, &fingerprint));
         self.contains_fingerprint(i0, i1, fingerprint)
     }
 
@@ -111,7 +112,9 @@ impl CuckooFilter {
         i0: usize,
         fingerprint: u64,
     ) {
-        let i1 = self.buckets.index(i0 as u64 ^ hash(hasher, &fingerprint));
+        let i1 = self
+            .buckets
+            .index(i0 as u64 ^ crate::hash(hasher, &fingerprint));
         if self.contains_fingerprint(i0, i1, fingerprint) {
             return;
         }
@@ -131,7 +134,9 @@ impl CuckooFilter {
         for _ in 0..self.max_kicks {
             fingerprint = self.buckets.random_swap(rng, i, fingerprint);
             prev_i = i;
-            i = self.buckets.index(i as u64 ^ hash(hasher, &fingerprint));
+            i = self
+                .buckets
+                .index(i as u64 ^ crate::hash(hasher, &fingerprint));
             if self.buckets.try_insert(i, fingerprint) {
                 return;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,11 +55,10 @@
 //! [cuckoo filter]: https://www.cs.cmu.edu/~dga/papers/cuckoo-conext2014.pdf
 //! [scalable bloom filters]: http://haslab.uminho.pt/cbm/files/dbloom.pdf
 #![warn(missing_docs)]
-extern crate rand;
-extern crate siphasher;
 
-pub use scalable_cuckoo_filter::{DefaultHasher, DefaultRng, ScalableCuckooFilter,
-                                 ScalableCuckooFilterBuilder};
+pub use crate::scalable_cuckoo_filter::{
+    DefaultHasher, DefaultRng, ScalableCuckooFilter, ScalableCuckooFilterBuilder,
+};
 
 mod bits;
 mod buckets;

--- a/src/scalable_cuckoo_filter.rs
+++ b/src/scalable_cuckoo_filter.rs
@@ -1,10 +1,9 @@
-use rand::{self, Rng, ThreadRng};
+use rand::{rngs::ThreadRng, Rng};
 use siphasher::sip::SipHasher13;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 
-use cuckoo_filter::CuckooFilter;
-use hash;
+use crate::cuckoo_filter::CuckooFilter;
 
 /// Default Hasher.
 pub type DefaultHasher = SipHasher13;
@@ -185,7 +184,7 @@ impl<T: Hash + ?Sized, H: Hasher + Clone, R: Rng> ScalableCuckooFilter<T, H, R> 
 
     /// Returns `true` if this filter may contain `item`, otherwise `false`.
     pub fn contains(&self, item: &T) -> bool {
-        let item_hash = hash(&self.hasher, item);
+        let item_hash = crate::hash(&self.hasher, item);
         self.filters
             .iter()
             .any(|f| f.contains(&self.hasher, item_hash))
@@ -195,7 +194,7 @@ impl<T: Hash + ?Sized, H: Hasher + Clone, R: Rng> ScalableCuckooFilter<T, H, R> 
     ///
     /// If the current filter becomes full, it will be expanded automatically.
     pub fn insert(&mut self, item: &T) {
-        let item_hash = hash(&self.hasher, item);
+        let item_hash = crate::hash(&self.hasher, item);
         let last = self.filters.len() - 1;
         for filter in self.filters.iter().take(last) {
             if filter.contains(&self.hasher, item_hash) {
@@ -222,7 +221,7 @@ impl<T: Hash + ?Sized, H: Hasher + Clone, R: Rng> ScalableCuckooFilter<T, H, R> 
             self.false_positive_probability / 2f64.powi(self.filters.len() as i32 + 1);
         let fingerprint_bitwidth = ((1.0 / probability).log2()
             + ((2 * self.entries_per_bucket) as f64).log2())
-            .ceil() as usize;
+        .ceil() as usize;
         let filter = CuckooFilter::new(
             fingerprint_bitwidth,
             self.entries_per_bucket,
@@ -250,7 +249,7 @@ mod test {
 
     #[test]
     fn insert_works() {
-        use rand::{SeedableRng, StdRng};
+        use rand::{rngs::StdRng, SeedableRng};
 
         let mut seed = [0; 32];
         for i in 0..seed.len() {


### PR DESCRIPTION
Hi,
I have used this crate in a quick prototype and added a quick optional feature to enable serde support.

It also updates the code to the 2018 edition of rust and the rand dependency to 0.8.
Due to this changes I increased the version to 0.2.

