### PR TITLE
Add remove method

### DIFF
--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -125,6 +125,22 @@ impl Buckets {
     }
 
     #[inline]
+    pub fn remove_fingerprint(&mut self, bucket_index: usize, fingerprint: u64) -> bool {
+        if fingerprint == 0 {
+            println!("Fingerprint zero");
+            return false;
+        }
+        for i in 0..self.entries_per_bucket {
+            let f = self.get_fingerprint(bucket_index, i);
+            if f == fingerprint {
+                self.set_fingerprint(bucket_index, i, 0);
+                return true;
+            }
+        }
+        false
+    }
+
+    #[inline]
     fn set_fingerprint(&mut self, bucket_index: usize, entry_index: usize, fingerprint: u64) {
         let offset = self.bucket_bitwidth * bucket_index + self.fingerprint_bitwidth * entry_index;
         self.bits

--- a/src/cuckoo_filter.rs
+++ b/src/cuckoo_filter.rs
@@ -83,7 +83,9 @@ impl CuckooFilter {
             .buckets
             .index(i0 as u64 ^ crate::hash(hasher, &fingerprint));
 
-        let removed = if self.buckets.contains(i0, fingerprint) {
+        let removed = if self.exceptional_items.contains(i0, i1, fingerprint) {
+            self.exceptional_items.remove(i0, i1, fingerprint)
+        } else if self.buckets.contains(i0, fingerprint) {
             self.buckets.remove_fingerprint(i0, fingerprint)
         } else if self.buckets.contains(i1, fingerprint) {
             self.buckets.remove_fingerprint(i1, fingerprint)
@@ -217,5 +219,15 @@ impl ExceptionalItems {
             }
         }
         self.0.push(item);
+    }
+
+    #[inline]
+    fn remove(&mut self, i0: usize, i1: usize, fingerprint: u64) -> bool {
+        let item = (fingerprint, cmp::min(i0, i1));
+        if let Ok(index) = self.0.binary_search(&item) {
+            self.0.remove(index);
+            return true;
+        }
+        false
     }
 }

--- a/src/scalable_cuckoo_filter.rs
+++ b/src/scalable_cuckoo_filter.rs
@@ -230,7 +230,7 @@ impl<T: Hash + ?Sized, H: Hasher + Clone, R: Rng> ScalableCuckooFilter<T, H, R> 
         let item_hash = crate::hash(&self.hasher, item);
         self.filters
             .iter_mut()
-            .for_each(|f| f.remove(&mut self.hasher, item_hash));
+            .for_each(|f| f.remove(&self.hasher, item_hash));
     }
 
     fn grow(&mut self) {

--- a/src/scalable_cuckoo_filter.rs
+++ b/src/scalable_cuckoo_filter.rs
@@ -224,7 +224,7 @@ impl<T: Hash + ?Sized, H: Hasher + Clone, R: Rng> ScalableCuckooFilter<T, H, R> 
             f.shrink_to_fit(&self.hasher, &mut self.rng);
         }
     }
-    
+
     /// Removes `item` from this filter.
     pub fn remove(&mut self, item: &T) {
         let item_hash = crate::hash(&self.hasher, item);
@@ -310,11 +310,6 @@ mod test {
         for i in 0..10_000 {
             filter.remove(&i);
             assert!(!filter.contains(&i));
-            //assert!(!filter.contains(&i));
-            //println!("{}", i);
-            //if filter.contains(&i) {
-            //    println!("{i}");
-            //}
         }
     }
 


### PR DESCRIPTION
This addresses https://github.com/sile/scalable_cuckoo_filter/issues/3.

I marked this as a draft because the remove method is not working properly yet.
The unit test fails because `contains` returns true for a few of the removed elements.
I think this shouldn't happen with a false positive prob of 0.00001.

I will look into this further but if there is something obvious I'm missing, let me know :)