### PR TITLE
Fix false negatives that may result from the removal of items

### DIFF
--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -188,7 +188,6 @@ impl<'a> Iterator for Iter<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use rand;
 
     #[test]
     fn it_works() {

--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -85,8 +85,6 @@ impl Buckets {
             let f = self.get_fingerprint(bucket_index, i);
             if f == fingerprint {
                 return true;
-            } else if f == 0 {
-                break;
             }
         }
         false
@@ -101,7 +99,6 @@ impl Buckets {
                 self.set_fingerprint(bucket_index, i, fingerprint);
                 return true;
             }
-            debug_assert_ne!(f, fingerprint);
         }
         false
     }
@@ -119,7 +116,6 @@ impl Buckets {
 
         debug_assert_ne!(fingerprint, 0);
         debug_assert_eq!(fingerprint, self.get_fingerprint(bucket_index, i));
-        debug_assert_ne!(f, fingerprint);
         debug_assert_ne!(f, 0);
         f
     }

--- a/src/cuckoo_filter.rs
+++ b/src/cuckoo_filter.rs
@@ -178,7 +178,7 @@ impl CuckooFilter {
                 return true;
             }
         }
-        return self.exceptional_items.insert(prev_i, i, fingerprint);
+        self.exceptional_items.insert(prev_i, i, fingerprint)
     }
 }
 
@@ -222,11 +222,15 @@ impl ExceptionalItems {
     fn insert(&mut self, i0: usize, i1: usize, fingerprint: u64) -> bool {
         let item = (fingerprint, cmp::min(i0, i1));
         for i in 0..self.0.len() {
-            if item == self.0[i] {
-                return false;
-            } else if item < self.0[i] {
-                self.0.insert(i, item);
-                return true;
+            match item.cmp(&self.0[i]) {
+                cmp::Ordering::Equal => {
+                    return false;
+                }
+                cmp::Ordering::Less => {
+                    self.0.insert(i, item);
+                    return true;
+                }
+                cmp::Ordering::Greater => {}
             }
         }
         self.0.push(item);

--- a/src/cuckoo_filter.rs
+++ b/src/cuckoo_filter.rs
@@ -221,9 +221,11 @@ impl ExceptionalItems {
     #[inline]
     fn insert(&mut self, i0: usize, i1: usize, fingerprint: u64) -> bool {
         let item = (fingerprint, cmp::min(i0, i1));
+        // TODO: use binary search
         for i in 0..self.0.len() {
             match item.cmp(&self.0[i]) {
                 cmp::Ordering::Equal => {
+                    // TODO: allow duplicates
                     return false;
                 }
                 cmp::Ordering::Less => {

--- a/src/cuckoo_filter.rs
+++ b/src/cuckoo_filter.rs
@@ -76,7 +76,7 @@ impl CuckooFilter {
     }
 
     #[inline]
-    pub fn remove<H: Hasher + Clone>(&mut self, hasher: &H, item_hash: u64) {
+    pub fn remove<H: Hasher + Clone>(&mut self, hasher: &H, item_hash: u64) -> bool {
         let fingerprint = self.buckets.fingerprint(item_hash);
         let i0 = self.buckets.index(item_hash);
         let i1 = self
@@ -96,6 +96,8 @@ impl CuckooFilter {
         if removed {
             self.item_count -= 1;
         }
+
+        removed
     }
 
     #[inline]
@@ -142,9 +144,6 @@ impl CuckooFilter {
         let i1 = self
             .buckets
             .index(i0 as u64 ^ crate::hash(hasher, &fingerprint));
-        if self.contains_fingerprint(i0, i1, fingerprint) {
-            return;
-        }
         self.item_count += 1;
 
         if fingerprint == 0 {

--- a/src/cuckoo_filter.rs
+++ b/src/cuckoo_filter.rs
@@ -141,10 +141,10 @@ impl CuckooFilter {
         i0: usize,
         fingerprint: u64,
     ) {
-        self.item_count += 1;
         let i1 = self
             .buckets
             .index(i0 as u64 ^ crate::hash(hasher, &fingerprint));
+        self.item_count += 1;
 
         if fingerprint == 0 {
             self.exceptional_items.insert(i0, i1, 0);

--- a/src/cuckoo_filter.rs
+++ b/src/cuckoo_filter.rs
@@ -167,7 +167,7 @@ impl CuckooFilter {
                 return;
             }
         }
-        self.exceptional_items.insert(prev_i, i, fingerprint)
+        self.exceptional_items.insert(prev_i, i, fingerprint);
     }
 }
 

--- a/src/scalable_cuckoo_filter.rs
+++ b/src/scalable_cuckoo_filter.rs
@@ -203,6 +203,30 @@ impl<T: Hash + ?Sized, H: Hasher + Clone, R: Rng> ScalableCuckooFilter<T, H, R> 
     /// Inserts `item` into this filter.
     ///
     /// If the current filter becomes full, it will be expanded automatically.
+    ///
+    /// # Note
+    ///
+    /// Cuckoo Filter algorithm is unable to differentiate between two items with
+    /// the same fingerprint, so every [`insert`] method call will add a new entry
+    /// even if the same item is inserted multiple times.
+    ///
+    /// This behavior is necessary to avoid false negatives when using the [`remove`] method.
+    /// However, if you do not plan to use the [`remove`] method, you can prevent potential
+    /// duplicate insertions by checking for the existence of the item before insertion,
+    /// as shown below:
+    ///
+    /// ```
+    /// use scalable_cuckoo_filter::ScalableCuckooFilter;
+    ///
+    /// let mut filter = ScalableCuckooFilter::new(1000, 0.001);
+    /// let items = ["foo", "bar", "foo", "baz"];
+    ///
+    /// for item in &items {
+    ///     if !filter.contains(item) {
+    ///         filter.insert(item);
+    ///     }
+    /// }
+    /// ```
     pub fn insert(&mut self, item: &T) {
         let item_hash = crate::hash(&self.hasher, item);
         let last = self.filters.len() - 1;

--- a/src/scalable_cuckoo_filter.rs
+++ b/src/scalable_cuckoo_filter.rs
@@ -345,6 +345,20 @@ mod test {
     }
 
     #[test]
+    fn fingerprint_collision_remove_works() {
+        let mut filter = ScalableCuckooFilter::new(1000, 0.001);
+        filter.insert("foo");
+        filter.insert("foo");
+        assert!(filter.contains("foo"));
+
+        filter.remove("foo");
+        assert!(filter.contains("foo"));
+
+        filter.remove("foo");
+        assert!(!filter.contains("foo"));
+    }
+
+    #[test]
     fn shrink_to_fit_works() {
         let mut filter = ScalableCuckooFilter::new(1000, 0.001);
         for i in 0..100 {

--- a/src/scalable_cuckoo_filter.rs
+++ b/src/scalable_cuckoo_filter.rs
@@ -396,8 +396,6 @@ mod test {
         assert_eq!(filter.bits(), 1792);
     }
 
-    #[cfg(feature = "serde_support")]
-    use serde_json;
     #[test]
     #[cfg(feature = "serde_support")]
     fn serialize_dezerialize_works() {


### PR DESCRIPTION
This PR fixes an issue reported in the comment https://github.com/sile/scalable_cuckoo_filter/pull/4#issuecomment-2033055195 .

Copilot generated summary
--------------------------------------

This pull request includes changes to the `src/buckets.rs`, `src/cuckoo_filter.rs`, and `src/scalable_cuckoo_filter.rs` files in the Cuckoo Filter implementation. The changes primarily focus on improving the `remove` method's functionality, simplifying the `insert` method, and enhancing the fingerprint collision handling in the filter. 

Changes to the `remove` method:

* [`src/cuckoo_filter.rs`](diffhunk://#diff-3a66a7511461b63b6fa98f568bc4ef826d67b4d00a8f56f2b03c723b0a3b6ca1L79-R79): The `remove` method in the `impl CuckooFilter {` block now returns a boolean value indicating whether the removal was successful. This change is reflected in the method signature and the addition of a return statement. [[1]](diffhunk://#diff-3a66a7511461b63b6fa98f568bc4ef826d67b4d00a8f56f2b03c723b0a3b6ca1L79-R79) [[2]](diffhunk://#diff-3a66a7511461b63b6fa98f568bc4ef826d67b4d00a8f56f2b03c723b0a3b6ca1R99-R100)

Changes to the `insert` method:

* [`src/cuckoo_filter.rs`](diffhunk://#diff-3a66a7511461b63b6fa98f568bc4ef826d67b4d00a8f56f2b03c723b0a3b6ca1R144-L148): The `insert` method in the `impl CuckooFilter {` block has been simplified. The check for the existence of a fingerprint before incrementing the `item_count` has been removed.
* [`src/scalable_cuckoo_filter.rs`](diffhunk://#diff-df83c1c5aa6de7bd1c102b80a3e388153c733c275e2d9060c06638635aa2330fR206-L214): The `insert` method in the `impl<T: Hash + ?Sized, H: Hasher + Clone, R: Rng> ScalableCuckooFilter<T, H, R>` block has been modified. The iteration over filters to check for item existence has been removed. An explanatory note has been added to the method documentation to clarify the behavior of the filter when the same item is inserted multiple times.

Changes to fingerprint collision handling:

* [`src/buckets.rs`](diffhunk://#diff-30677bffa5b796cabe0242c8dc9d4bf65f2c1678ea22489ec9f9ad233d7a58e4L88-L89): Several debug assertions checking for fingerprint collisions have been removed from the `impl Buckets {` block. [[1]](diffhunk://#diff-30677bffa5b796cabe0242c8dc9d4bf65f2c1678ea22489ec9f9ad233d7a58e4L88-L89) [[2]](diffhunk://#diff-30677bffa5b796cabe0242c8dc9d4bf65f2c1678ea22489ec9f9ad233d7a58e4L104) [[3]](diffhunk://#diff-30677bffa5b796cabe0242c8dc9d4bf65f2c1678ea22489ec9f9ad233d7a58e4L122)
* [`src/scalable_cuckoo_filter.rs`](diffhunk://#diff-df83c1c5aa6de7bd1c102b80a3e388153c733c275e2d9060c06638635aa2330fL231-R254): The `remove` method in the `impl<T: Hash + ?Sized, H: Hasher + Clone, R: Rng> ScalableCuckooFilter<T, H, R>` block has been modified to stop iterating over filters once an item has been successfully removed. A new test case has been added to verify the correct behavior when removing items with the same fingerprint. [[1]](diffhunk://#diff-df83c1c5aa6de7bd1c102b80a3e388153c733c275e2d9060c06638635aa2330fL231-R254) [[2]](diffhunk://#diff-df83c1c5aa6de7bd1c102b80a3e388153c733c275e2d9060c06638635aa2330fR368-R381)

Other changes:

* [`src/cuckoo_filter.rs`](diffhunk://#diff-3a66a7511461b63b6fa98f568bc4ef826d67b4d00a8f56f2b03c723b0a3b6ca1L214-R214): The `insert` method in the `impl ExceptionalItems {` block has been simplified to use a binary search for insertion.
* [`src/cuckoo_filter.rs`](diffhunk://#diff-3a66a7511461b63b6fa98f568bc4ef826d67b4d00a8f56f2b03c723b0a3b6ca1L171-R170): The `insert` method in the `impl CuckooFilter {` block has been modified to return directly after inserting an item into `exceptional_items`.