### PR TITLE
Introduce insert_reference_type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! ```
 //! use scalable_cuckoo_filter::ScalableCuckooFilter;
 //!
-//! let mut filter = ScalableCuckooFilter::new(100, 0.001);
+//! let mut filter = ScalableCuckooFilter::<str>::new(100, 0.001);
 //! assert!(!filter.contains("foo"));
 //! filter.insert("foo");
 //! assert!(filter.contains("foo"));
@@ -18,7 +18,7 @@
 //! ```
 //! use scalable_cuckoo_filter::ScalableCuckooFilter;
 //!
-//! let mut filter = ScalableCuckooFilter::new(100, 0.001);
+//! let mut filter = ScalableCuckooFilter::<usize>::new(100, 0.001);
 //! assert_eq!(filter.capacity(), 128);
 //!
 //! for i in 0..1000 {
@@ -32,7 +32,7 @@
 //! ```
 //! use scalable_cuckoo_filter::ScalableCuckooFilter;
 //!
-//! let mut filter = ScalableCuckooFilter::new(1000, 0.001);
+//! let mut filter = ScalableCuckooFilter::<usize>::new(1000, 0.001);
 //! for i in 0..100 {
 //!     filter.insert(&i);
 //! }


### PR DESCRIPTION
I've really enjoyed scalable_cuckoo_filter, thank you!

I need to deduplicate a `(&[u8], Option<&[u8]>, Option<&[u8]>, Option<&[u8]>,) `and I don't want to do cloning just to get a `&[u8]` (millions of entries...).

Unfortunately,  declaring a `ScalableCuckooFilter<MyTuple>`
and `MyTuple<'a> = (&'a [u8], Option<&'a [u8], ...)`
makes rustc think that insert() keeps the reference around.

The problem is that rust ties the inner references to the struct's lifetime, even if you introduce a lifetime parameter and  change the `PhantomData<T>` to a `PhantomData<&'b T>`.

I could instead have a `ScalableCuckooFilter<T = u64>`,
and pass in a hash of `MyTuple`, which then get's immediately hashed again, but it's hard to envision if that would still get the cuckoo's guarantees.

One could remove T from the `ScaleableCuckooFilter`, and put the constraints on query/insert - but that would allow you to mix types in one filter. I don't think that'd be sensible.

Or we can export `crate::hash`, make `hasher` on `ScalableCuckoFilter` pub, and introduce an `unsafe insert_by_hash(&mut self, item_hash: u64)` function.

Or, combining the ideas, adding this to ScalableCuckooFilter:
`pub unsafe fn insert_reference_type<U: Hash + ?Sized>(&mut self, item: &U) `
(which this PR does). 
That does not require the user to know anything about the hash, 
just to uphold the type invariant.

(Seems rust's been missing a type equality constraint for 10+ years now:
https://github.com/rust-lang/rust/issues/20041 )
