### PR TITLE
Remove Coveralls integration

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -1,3 +1,0 @@
-ignore-not-existing: true
-ignore:
-  - "../*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,3 @@
-# Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
-
 name: CI
 
 on: [push, pull_request]
@@ -13,20 +11,9 @@ jobs:
         toolchain: [stable, beta, nightly]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install ${{ matrix.toolchain }} toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-features --all
+        uses: actions/checkout@v4
+      - run: rustup update ${{ matrix.toolchain }}
+      - run: cargo check --all
 
   test:
     name: Test Suite
@@ -36,20 +23,9 @@ jobs:
         toolchain: [stable, beta, nightly]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install ${{ matrix.toolchain }} toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features --all
+        uses: actions/checkout@v4
+      - run: rustup update ${{ matrix.toolchain }}
+      - run: cargo test --all
 
   lints:
     name: Lints
@@ -59,67 +35,7 @@ jobs:
         toolchain: [stable, beta, nightly]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install ${{ matrix.toolchain }} toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-          components: rustfmt, clippy
-
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-      - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --all -- -D warnings
-
-  grcov:
-    name: Coverage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-
-      - name: Execute tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all --all-features
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
-          RUSTDOCFLAGS: "-Cpanic=abort"
-
-      - name: Gather coverage data
-        id: coverage
-        uses: actions-rs/grcov@v0.1
-
-      - name: Coveralls upload
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
-          path-to-lcov: ${{ steps.coverage.outputs.report }}
-
-  grcov_finalize:
-    runs-on: ubuntu-latest
-    needs: grcov
-    steps:
-      - name: Coveralls finalization
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
+        uses: actions/checkout@v4
+      - run: rustup update ${{ matrix.toolchain }}
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,6 @@ license = "MIT"
 [features]
 serde_support = ["serde","serde_bytes"]
 
-[badges]
-coveralls = {repository = "sile/scalable_cuckoo_filter"}
-
 [dependencies]
 rand = "0.8"
 siphasher = "1"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ scalable_cuckoo_filter
 [![scalable_cuckoo_filter](https://img.shields.io/crates/v/scalable_cuckoo_filter.svg)](https://crates.io/crates/scalable_cuckoo_filter)
 [![Documentation](https://docs.rs/scalable_cuckoo_filter/badge.svg)](https://docs.rs/scalable_cuckoo_filter)
 [![Actions Status](https://github.com/sile/scalable_cuckoo_filter/workflows/CI/badge.svg)](https://github.com/sile/scalable_cuckoo_filter/actions)
-[![Coverage Status](https://coveralls.io/repos/github/sile/scalable_cuckoo_filter/badge.svg?branch=master)](https://coveralls.io/github/sile/scalable_cuckoo_filter?branch=master)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 A variant of [Cuckoo Filter][cuckoo filter] whose size automatically scales as necessary.


### PR DESCRIPTION
Copilot Summary
------------------

This pull request simplifies the CI workflow, removes outdated coverage-related configurations, and cleans up unused badges and metadata. The most important changes include updating the CI workflow to use simpler, native commands, removing grcov coverage jobs, and cleaning up unused badges and configuration in `Cargo.toml` and `README.md`.

### CI Workflow Simplification:
* Updated `.github/workflows/ci.yml` to replace `actions-rs` actions with native `rustup` and `cargo` commands for tasks like toolchain installation, checking, testing, formatting, and linting. This reduces dependency on external actions and simplifies the workflow. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL16-R16) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL39-R28) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL62-R41)

### Removal of Coverage-Related Configurations:
* Removed the `grcov` and `grcov_finalize` jobs from `.github/workflows/ci.yml`, as well as the associated `grcov.yml` configuration file. This eliminates the generation and upload of test coverage reports. [[1]](diffhunk://#diff-4b1b577a498f00eea3f4bab5f630e85e846d0b39100b4b929c4abd53efe31509L1-L3) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL62-R41)

### Cleanup of Unused Metadata and Badges:
* Removed the `coveralls` badge from `README.md` and the corresponding `badges` section from `Cargo.toml`, as they are no longer relevant after the removal of coverage reporting. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L17-L19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7)