### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/bits.rs
+++ b/src/bits.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 pub struct Bits(#[cfg_attr(feature = "serde_support", serde(with = "serde_bytes"))] Vec<u8>);
 impl Bits {
     pub fn new(size_hint: usize) -> Self {
-        Bits(vec![0; (size_hint + 7) / 8])
+        Bits(vec![0; size_hint.div_ceil(8)])
     }
 
     #[inline]
@@ -18,7 +18,7 @@ impl Bits {
     pub fn get_uint(&self, position: usize, size: usize) -> u64 {
         let mut value = 0;
         let start = position / 8;
-        let end = (position + size + 7) / 8;
+        let end = (position + size).div_ceil(8);
         for (i, &b) in self.0[start..end].iter().enumerate() {
             value |= u64::from(b) << (i * 8);
         }

--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -162,7 +162,7 @@ impl<'a> Iter<'a> {
         }
     }
 }
-impl<'a> Iterator for Iter<'a> {
+impl Iterator for Iter<'_> {
     type Item = (usize, u64);
     fn next(&mut self) -> Option<Self::Item> {
         loop {

--- a/src/cuckoo_filter.rs
+++ b/src/cuckoo_filter.rs
@@ -24,7 +24,7 @@ impl CuckooFilter {
         max_kicks: usize,
     ) -> Self {
         let number_of_buckets_hint =
-            (number_of_items_hint + entries_per_bucket - 1) / entries_per_bucket;
+            number_of_items_hint.div_ceil(entries_per_bucket);
         let buckets = Buckets::new(
             fingerprint_bitwidth,
             entries_per_bucket,
@@ -104,7 +104,7 @@ impl CuckooFilter {
     pub fn shrink_to_fit<H: Hasher + Clone, R: Rng>(&mut self, hasher: &H, rng: &mut R) {
         let entries_per_bucket = self.buckets.entries_per_bucket();
         let shrunk_buckets_len = Buckets::required_number_of_buckets(
-            (self.item_count + entries_per_bucket - 1) / entries_per_bucket,
+            self.item_count.div_ceil(entries_per_bucket),
         );
         if shrunk_buckets_len < self.buckets.len() {
             let mut shrunk_filter = CuckooFilter::new(
@@ -198,7 +198,7 @@ impl ExceptionalItems {
     fn contains_kicked_out_entries(&self) -> bool {
         self.0
             .last()
-            .map_or(false, |&(fingerprint, _)| fingerprint != 0)
+            .is_some_and(|&(fingerprint, _)| fingerprint != 0)
     }
 
     #[inline]

--- a/src/cuckoo_filter.rs
+++ b/src/cuckoo_filter.rs
@@ -23,8 +23,7 @@ impl CuckooFilter {
         number_of_items_hint: usize,
         max_kicks: usize,
     ) -> Self {
-        let number_of_buckets_hint =
-            number_of_items_hint.div_ceil(entries_per_bucket);
+        let number_of_buckets_hint = number_of_items_hint.div_ceil(entries_per_bucket);
         let buckets = Buckets::new(
             fingerprint_bitwidth,
             entries_per_bucket,
@@ -103,9 +102,8 @@ impl CuckooFilter {
     #[inline]
     pub fn shrink_to_fit<H: Hasher + Clone, R: Rng>(&mut self, hasher: &H, rng: &mut R) {
         let entries_per_bucket = self.buckets.entries_per_bucket();
-        let shrunk_buckets_len = Buckets::required_number_of_buckets(
-            self.item_count.div_ceil(entries_per_bucket),
-        );
+        let shrunk_buckets_len =
+            Buckets::required_number_of_buckets(self.item_count.div_ceil(entries_per_bucket));
         if shrunk_buckets_len < self.buckets.len() {
             let mut shrunk_filter = CuckooFilter::new(
                 self.buckets.fingerprint_bitwidth(),


### PR DESCRIPTION
## Copilot Summary

This pull request introduces several improvements to the codebase by replacing manual calculations with the `div_ceil` method for clarity and correctness, updating iterator implementation for better readability, and using the `is_some_and` method for improved expressiveness. Below are the most important changes grouped by theme:

### Code Clarity and Correctness:
* Replaced manual ceiling division calculations with the `div_ceil` method for better readability and accuracy in `Bits::new`, `Bits::get_uint`, and several methods in `CuckooFilter`. (`src/bits.rs`: [[1]](diffhunk://#diff-553e280a1b69788d3814325b94934b23ac740f2262ec223fde8d525f974fe67dL9-R9) [[2]](diffhunk://#diff-553e280a1b69788d3814325b94934b23ac740f2262ec223fde8d525f974fe67dL21-R21); `src/cuckoo_filter.rs`: [[3]](diffhunk://#diff-3a66a7511461b63b6fa98f568bc4ef826d67b4d00a8f56f2b03c723b0a3b6ca1L26-R26) [[4]](diffhunk://#diff-3a66a7511461b63b6fa98f568bc4ef826d67b4d00a8f56f2b03c723b0a3b6ca1L106-R106)

### Expressiveness:
* Updated the `contains_kicked_out_entries` method in `ExceptionalItems` to use the `is_some_and` method, making the code more expressive and concise. (`src/cuckoo_filter.rs`: [src/cuckoo_filter.rsL201-R199](diffhunk://#diff-3a66a7511461b63b6fa98f568bc4ef826d67b4d00a8f56f2b03c723b0a3b6ca1L201-R199))

### Code Simplification:
* Simplified the iterator implementation for `Iter` by replacing the lifetime parameter `'a` with the underscore `_`, improving readability. (`src/buckets.rs`: [src/buckets.rsL165-R165](diffhunk://#diff-30677bffa5b796cabe0242c8dc9d4bf65f2c1678ea22489ec9f9ad233d7a58e4L165-R165))