### PR TITLE
Update rand dependency from 0.8 to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 serde_support = ["serde","serde_bytes"]
 
 [dependencies]
-rand = "0.8"
+rand = "0.9"
 siphasher = "1"
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 serde_bytes = { version = "0.11", optional = true }

--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -110,7 +110,7 @@ impl Buckets {
         bucket_index: usize,
         fingerprint: u64,
     ) -> u64 {
-        let i = rng.gen_range(0..self.entries_per_bucket);
+        let i = rng.random_range(0..self.entries_per_bucket);
         let f = self.get_fingerprint(bucket_index, i);
         self.set_fingerprint(bucket_index, i, fingerprint);
 
@@ -202,7 +202,7 @@ mod test {
         }
         assert!(!buckets.try_insert(333, 104)); // full
 
-        let old = buckets.random_swap(&mut rand::thread_rng(), 333, 104);
+        let old = buckets.random_swap(&mut rand::rng(), 333, 104);
         assert!(buckets.contains(333, 104));
         assert!(!buckets.contains(333, old));
     }

--- a/src/cuckoo_filter.rs
+++ b/src/cuckoo_filter.rs
@@ -153,7 +153,7 @@ impl CuckooFilter {
         }
 
         let mut fingerprint = fingerprint;
-        let mut i = if rng.gen::<bool>() { i0 } else { i1 };
+        let mut i = if rng.random::<bool>() { i0 } else { i1 };
         let mut prev_i = i;
         for _ in 0..self.max_kicks {
             fingerprint = self.buckets.random_swap(rng, i, fingerprint);

--- a/src/scalable_cuckoo_filter.rs
+++ b/src/scalable_cuckoo_filter.rs
@@ -30,7 +30,7 @@ impl ScalableCuckooFilterBuilder<DefaultHasher, DefaultRng> {
             entries_per_bucket: 4,
             max_kicks: 512,
             hasher: SipHasher13::new(),
-            rng: rand::thread_rng(),
+            rng: rand::rng(),
         }
     }
 }


### PR DESCRIPTION
## Copilot Summary

This pull request updates the `rand` crate version and replaces deprecated methods in the codebase with their updated equivalents. These changes improve compatibility with the latest version of the `rand` crate and ensure the code adheres to the updated API.

### Dependency Update:
* Updated the `rand` crate from version `0.8` to `0.9` in `Cargo.toml`.

### Code Adjustments for API Changes:
* Replaced `rng.gen_range` with `rng.random_range` in the `Buckets` implementation in `src/buckets.rs`.
* Updated the test in `src/buckets.rs` to use `rand::rng()` instead of `rand::thread_rng()` for generating random numbers.
* Changed `rng.gen::<bool>()` to `rng.random::<bool>()` in the `CuckooFilter` implementation in `src/cuckoo_filter.rs`.
* Replaced `rand::thread_rng()` with `rand::rng()` in the `ScalableCuckooFilterBuilder` implementation in `src/scalable_cuckoo_filter.rs`.