### PR TITLE
fix: Buckets iterator skipping causes shrink-induced data loss

### DIFF
--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -173,12 +173,10 @@ impl Iterator for Iter<'_> {
                 self.entry_i = 0;
             } else {
                 let f = self.buckets.get_fingerprint(self.bucket_i, self.entry_i);
-                if f == 0 {
-                    self.entry_i += 1;
-                } else {
-                    let bucket = self.bucket_i;
-                    self.entry_i += 1;
-                    return Some((bucket, f));
+                self.entry_i += 1;
+                
+                if f != 0 {
+                    return Some((self.bucket_i, f));
                 }
             }
         }


### PR DESCRIPTION
**Issue**

When `Buckets::iter` was walking a bucket and hit the first empty slot, it jumped to next bucket instead of checking remaining slots.

During `shrink_to_fit` this iterator does reinsertion of fingerprints into a new table. If you inserted several items, removed one from the middle, and later called `shrink_to_fit` any fingerprints stored after that gap were skipped and never reinserted, so the filter forgot them -> false negative.

This PR makes `Buckets::iter` keep scanning the current bucket after it sees an empty slot, so every non-zero fingerprint still in the bucket is yielded.

**Fix**

`shrink_to_fit` now reinserts all retained entries, preserving membership information.

The new test creates a bucket with two fingerprints, removes the first to create a hole, then iterates. Under the old code it returns an empty list, but now it still yields the remaining fingerprint, proving the iterator no longer drops entries after gaps.

**Perf**

Should be no meaningful perf impact. Iterator now steps through at most the remaining slots in the same bucket before moving on. Each bucket only has `entries_per_bucket` (default 4) slots, so the extra work is bounded and negligible.

Bench confirms this:

- insert/precision/0.1 median: before 100.8 ns, after 94.6 ns
- insert/precision/0.00001 median: before 158.5 ns, after 165.2 ns (not significant)
- contains/precision/0.1 median: before 22.25 ns, after 22.37 ns
- contains/precision/0.00001 median: before 34.41 ns, after 34.40 ns